### PR TITLE
Data Viz fix dates

### DIFF
--- a/scripts/views/dataViz.js
+++ b/scripts/views/dataViz.js
@@ -162,13 +162,12 @@
     var start = dateStart.valueOf();
     var end = dateEnd.valueOf();
     var dates = [];
-    
+
     while (dateEnd > dateStart || dateStart.format('M') === dateEnd.format('M')) {
       dates.push(dateStart.format('YYYY-M'));
       dateStart.add(1,'month');
     }
     dates.forEach(function(date){
-      console.log(date);
       dataviz.getPastEvents('townHallsOld/' + date, start, end, dataviz.lookupMembers, dataviz.houseMemberMapping,  dataviz.sentateHouseMapping);
     });
   };


### PR DESCRIPTION
This PR fixes our data visualization error.

Error occured because of outdated iterator for months:
2018-0 was being read as '2017-0' with Str concatenation method.

Now months are pushed to dates array from a moment.js format method parsing. #144 