### PR TITLE
update true false values to match boolean in editor dropdown

### DIFF
--- a/scripts/views/mocEditorView.js
+++ b/scripts/views/mocEditorView.js
@@ -71,6 +71,8 @@
     event.preventDefault();
     var $input = $(this).parents('.input-group').find('input');
     var value = $(this).attr('data-value');
+    if (value === 'true') { value = true }
+    if (value === 'false') { value = false }
     $input.val(value);
     Moc.currentMoc[$input.attr('id')] = value;
   };


### PR DESCRIPTION
Fixes error resulting in 'false' and 'true' values being saved as string instead of boolean values
#114 #136 