### PR TITLE
add meetingtype check to avoid error when searching by wrong key

### DIFF
--- a/scripts/views/eventView.js
+++ b/scripts/views/eventView.js
@@ -153,6 +153,9 @@
     document.getElementById('download-csv-events-list').appendChild(para);
     var dates = eventHandler.getDateRange().dates;
     var key = $('#lookup-key').val();
+    if (key === 'Meeting_Type') {
+      key = 'meetingType';
+    }
     var value = $('#lookup-value').val();
     var totalCount = 0;
     var allEvents = [];


### PR DESCRIPTION
This PR adds a check to html value 'Meeting_Type' to convert to meetingType before being used as filter for old town hall lookups.

-This error was causing meeting type not to work