### PR TITLE
fix state cap typo in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
                               <option value="Member">Member</option>
                               <option value="Meeting_Type">Event Type</option>
                               <option value="District">District</option>
-                              <option value="state">State</option>
+                              <option value="State">State</option>
                               <option value="Party">Party</option>
                               <option value="Date">Date</option>
                             </select>

--- a/scripts/models/event0.js
+++ b/scripts/models/event0.js
@@ -51,7 +51,6 @@
     var db = firebasedb;
     var ref = db.ref('/townHallsOld/' + dateKey);
     var totals = new Set();
-    console.log(key, value);
     return new Promise (function(resolve){
       ref.once('value').then(function(snapshot) {
         snapshot.forEach(function(oldTownHall) {


### PR DESCRIPTION
lower case type in index.html is causing state searches to not return any values:
test case:
Search by: 'State'
Type: 'Oregon'

This PR makes a type change in index to fix this issue.