### PR TITLE
Issue 218 missing member to moc editor

### DIFF
--- a/templates/newMOC.handlebars
+++ b/templates/newMOC.handlebars
@@ -50,9 +50,9 @@
           </div>
         </div>
         <div class="form-group col-md-12">
-        <label for="in_office">Missing Member?</label>
+        <label for="missingMember">Missing Member?</label>
         <div class="input-group">
-          <input type="text" class="form-control" aria-label="..." id="in_office" value="{{missingMember}}" placeholder="Missing Member"
+          <input type="text" class="form-control" aria-label="..." id="missingMember" value="{{missingMember}}" placeholder="Missing Member"
             readonly>
           <div class="input-group-btn">
             <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
Issue #218 

The problem was that there was no field connected to missingMember in the MOC Editor template. Adding the field created a new field Missing_Member, which wouldn't work. Added the field to the MOC Editor template and connected it to missingMember